### PR TITLE
Marking add-on as critical

### DIFF
--- a/k8s-install/canal.yaml
+++ b/k8s-install/canal.yaml
@@ -14,6 +14,9 @@ spec:
       k8s-app: canal-node
   template:
     metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
       labels:
         k8s-app: canal-node
     spec:


### PR DESCRIPTION
Rescheduler ensures that critical add-ons are always scheduled.