### PR TITLE
Marking add-on as critical

### DIFF
--- a/k8s-install/kubeadm/canal.yaml
+++ b/k8s-install/kubeadm/canal.yaml
@@ -53,6 +53,9 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
       labels:
         k8s-app: canal-etcd
     spec:


### PR DESCRIPTION
Rescheduler ensures that critical add-ons are always scheduled.