### PR TITLE
Allow the calico-policy controller and the canal setup batch job to r…

### DIFF
--- a/k8s-install/kubeadm/canal.yaml
+++ b/k8s-install/kubeadm/canal.yaml
@@ -244,6 +244,9 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
+  annotations:
+    kube-system scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated", "operator":"Exists"}]'
+    scheduler.alpha.kubernetes.io/critical-pod: ''
   name: configure-canal 
   namespace: kube-system
   labels:
@@ -288,6 +291,9 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations: 
+        kube-system scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated", "operator":"Exists"}]'
+        scheduler.alpha.kubernetes.io/critical-pod: ''
       name: calico-policy-controller
       namespace: kube-system
       labels:


### PR DESCRIPTION
Allow the calico-policy-controller and the canal-setup pods/job to run on the master which currently can't due to the taint put on the master node.

When starting up on Vagrant the master comes up well before the minions and the dns pod can't start until the network is available and so we have a number of pods stuck in pending or failing.  This change is to annotate the pods so that they tollerate the dedicated=master taint on the master node.

Everything does work once the some nodes come up but that can be a long a wait and this means that things are up and correctly configured a lot faster.